### PR TITLE
styles: Allow camera view to see pointer events

### DIFF
--- a/styles/module.css
+++ b/styles/module.css
@@ -11,6 +11,10 @@
     padding-bottom: 6px !important;
 }
 
+.camera-view {
+    pointer-events: all !important;
+}
+
 .camera-view.camera-box-dock{
     width: var(--camera-size) !important;
 }


### PR DESCRIPTION
Without this, hovering over the camera view doesn't show the user controls such as volume control / popout. The controls only come up when hovering over the player-name element, but moving the mouse to try to use the controls immediately hides them.